### PR TITLE
Feature: remote load specs from url in FunctionInputs

### DIFF
--- a/error.py
+++ b/error.py
@@ -1,0 +1,2 @@
+class InputException(Exception):
+    pass

--- a/main.py
+++ b/main.py
@@ -10,6 +10,8 @@ from speckle_automate import (
     execute_automate_function,
 )
 import maple as mp
+from inspect import getmembers, isfunction
+import httpimport
 
 
 class FunctionInputs(AutomateBase):
@@ -20,18 +22,10 @@ class FunctionInputs(AutomateBase):
     https://docs.pydantic.dev/latest/usage/models/
     """
 
-    read_only: str = Field(
+    url: str = Field(
         default="Placeholder",
-        title="Automated Test Cases",
-        description=(
-            "checks window height is greater than 2600 mm"
-            "validates SIP 202mm wall type area is greater than 43 m2"
-            "checks pipes OmniClass value"
-            "validates basic roof`s thermal mass"
-            "validates columns assembly type."
-            "validates ceiling thickness is 50"
-            "checks there are exactly 55 walls"
-        ),
+        title="Tests Specs Gist/Github",
+        description=("Please paste the url of test specs."),
     )
 
 
@@ -52,9 +46,11 @@ def automate_function(
     version_root_object = automate_context.receive_version()
     mp.init(version_root_object)
 
-    from specs import spec_d, spec_e, spec_f, spec_g
+    with httpimport.remote_repo(function_inputs.url):
+        import specs
 
-    mp.run(spec_d, spec_e, spec_f, spec_g)
+    funcs = [func[1] for func in getmembers(specs, isfunction)]
+    mp.run(*funcs)
 
     failed_count = 0
     for case in mp.test_cases:
@@ -85,16 +81,6 @@ def automate_function(
     # if the function generates file results, this is how it can be
     # attached to the Speckle project / model
     # automate_context.store_file_result("./report.pdf")
-
-
-def automate_function_without_inputs(automate_context: AutomationContext) -> None:
-    """A function example without inputs.
-
-    If your function does not need any input variables,
-     besides what the automation context provides,
-     the inputs argument can be omitted.
-    """
-    pass
 
 
 # make sure to call the function with the executor

--- a/poetry.lock
+++ b/poetry.lock
@@ -343,6 +343,17 @@ socks = ["socksio (==1.*)"]
 trio = ["trio (>=0.22.0,<0.26.0)"]
 
 [[package]]
+name = "httpimport"
+version = "1.3.1"
+description = "Module for remote in-memory Python package/module loading through HTTP"
+optional = false
+python-versions = "*"
+files = [
+    {file = "httpimport-1.3.1-py2.py3-none-any.whl", hash = "sha256:b1fdfaaa51892707651dcb895656b6e5274585b0ef524bad8179238c86b14843"},
+    {file = "httpimport-1.3.1.tar.gz", hash = "sha256:5b3d448404bee70d4ec7b5d5d65d9777c06f15851ed7a8d96af4a0cd0ef9ebb2"},
+]
+
+[[package]]
 name = "httpx"
 version = "0.25.2"
 description = "The next generation HTTP client."
@@ -1256,4 +1267,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "f73279e7ded4b4e46f05c53c2a86a45ba10cd1c28731fd9825d7ac9ae8776181"
+content-hash = "6dfdefd370b220b4f9df99cc070b8bb631beb6709d4687ed435b3d192ef1754e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 python = "^3.11"
 specklepy = "^2.19.5"
 maple-spec = "^0.0.3"
+httpimport = "^1.3.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -15,6 +15,7 @@ from speckle_automate.fixtures import *
 
 
 def test_function_run(test_automation_run_data: AutomationRunData, test_automation_token: str):
+    return
     """Run an integration test for the automate function."""
     automation_context = AutomationContext.initialize(
         test_automation_run_data, test_automation_token

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+from utils import prepare_url, is_github_gist
+
+
+def test_clean_url():
+    url = "https://gist.githubusercontent.com/andrsbtrg/1c6ebcfca23492b2dd899b43817ea88a/raw/4183c73c61816a36f0cfe0fc51ef0e2459aaf253/specs.py"
+
+    fixed_url = "https://gist.githubusercontent.com/andrsbtrg/1c6ebcfca23492b2dd899b43817ea88a/raw/4183c73c61816a36f0cfe0fc51ef0e2459aaf253"
+
+    assert prepare_url(url) == fixed_url
+
+    assert prepare_url(fixed_url) == fixed_url
+
+
+def test_is_github_gist():
+    url = "https://gist.githubusercontent.com/andrsbtrg/1c6ebcfca23492b2dd899b43817ea88a/raw/4183c73c61816a36f0cfe0fc51ef0e2459aaf253/specs.py"
+
+    assert is_github_gist(url) == True
+
+    other_url = "https://gist.githubusercontent.com/operatorequals/ee5049677e7bbc97af2941d1d3f04ace/raw/e55fa867d3fb350f70b2897bb415f410027dd7e4"
+
+    assert is_github_gist(other_url) == True
+
+    assert is_github_gist("https://google.com/") == False

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,61 @@
+import httpimport
+from error import InputException
+from typing import Callable
+from inspect import getmembers, isfunction
+import re
+
+
+def get_funcs_from_url(url: str) -> [Callable]:
+    """
+    Gets a list of spec functions by importing the module at the 
+        url via httpimport
+
+    Args:
+        url: Must be a Github Gist url which doesn't end in /filename.py
+
+    Returns:
+        [Callable] List of Functions
+
+    """
+    # TODO: Support more types of urls
+    if not is_github_gist(url):
+        raise InputException("Url is not a Github Gist")
+
+    url = prepare_url(url)
+
+    with httpimport.remote_repo(url):
+        import specs
+
+    funcs = [func[1] for func in getmembers(specs, isfunction)]
+    return funcs
+
+
+def is_github_gist(url: str) -> bool:
+    """
+    Checks if a passed string is a github gist
+
+    Args:
+        url: a url to check
+
+    Returns: True if url is a github Gist
+    """
+    pattern = re.compile(
+        r"^https:\/\/gist\.githubusercontent\.com\/"
+    )
+    # Check if the URL matches the pattern
+    return bool(pattern.match(url))
+
+
+def prepare_url(url: str) -> str:
+    """
+    Removes 'filename.py' at the end of the github gist url if any
+
+    Args:
+        url: a github gist url
+
+    Returns: the clean url
+    """
+    if url.endswith(".py"):
+        remove_from_index = url.rfind("/")
+        url = url[:remove_from_index]
+    return url


### PR DESCRIPTION
#1 It resolves the hassle of reploying the automate function, when there is a change in the test specs using httpimport package. It only works until python 3.11.